### PR TITLE
Fix Supabase integration and card image loading

### DIFF
--- a/cards.json
+++ b/cards.json
@@ -10,11 +10,11 @@
     "keyPhrase": "Прыгни в неизвестность — всё возможно.",
     "description": "Юноша стоит на краю обрыва, глядя в небо, не замечая опасности. Рядом — белая собака, символ инстинктов и верности.",
     "symbolism": "Обрыв — риск и возможности, белая роза — чистота намерений, узелок — прошлый опыт, собака — внутренний голос.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1GwjJI6U9-O0g5bkNfYehU1sBFK7alKHc",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1JMuH5gRQK5yu_pAlF7yc3XJ66lHwLIj2",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1GwjJI6U9-O0g5bkNfYehU1sBFK7alKHc",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1JMuH5gRQK5yu_pAlF7yc3XJ66lHwLIj2",
     "symbol": "🔮",
     "meaning": "Начало, невинность, спонтанность, свободный дух",
-    "image": "https://drive.google.com/uc?export=view&id=1GwjJI6U9-O0g5bkNfYehU1sBFK7alKHc"
+    "image": "https://drive.google.com/uc?export=download&id=1GwjJI6U9-O0g5bkNfYehU1sBFK7alKHc"
   },
   {
     "id": "MA_1",
@@ -27,11 +27,11 @@
     "keyPhrase": "Ты обладаешь всем, что нужно.",
     "description": "Фигура стоит у стола с символами четырёх мастей Таро. Он указывает одной рукой вверх, другой вниз — 'Как наверху, так и внизу'.",
     "symbolism": "Жезл, кубок, меч, пентакль — ресурсы и стихии, бесконечность над головой — вечное знание, жест — связь духовного и земного.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=159xF6IrCRTZBBSNOb7nmTXc6tzvWVB7R",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=10sIWms047WCmBhAYFpsXaFVuM_sgLl8O",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=159xF6IrCRTZBBSNOb7nmTXc6tzvWVB7R",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=10sIWms047WCmBhAYFpsXaFVuM_sgLl8O",
     "symbol": "🔮",
     "meaning": "Сила воли, проявление, вдохновение",
-    "image": "https://drive.google.com/uc?export=view&id=159xF6IrCRTZBBSNOb7nmTXc6tzvWVB7R"
+    "image": "https://drive.google.com/uc?export=download&id=159xF6IrCRTZBBSNOb7nmTXc6tzvWVB7R"
   },
   {
     "id": "MA_2",
@@ -44,11 +44,11 @@
     "keyPhrase": "Истина внутри тебя.",
     "description": "Таинственная женщина сидит между чёрной и белой колонной, с завесой за спиной. На коленях — Тора, священное знание.",
     "symbolism": "Колонны Боаз и Яхин — дуальность, завеса — скрытые истины, луна у ног — интуиция, гранат — тайные знания.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=122VXQD1cZm5YF3zJq17TAbKG4n41m8dg",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1Wx5L_0xsDuop1ivZLvPvf2IgWeartGC4",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=122VXQD1cZm5YF3zJq17TAbKG4n41m8dg",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1Wx5L_0xsDuop1ivZLvPvf2IgWeartGC4",
     "symbol": "🌙",
     "meaning": "Интуиция, тайны, внутренний голос",
-    "image": "https://drive.google.com/uc?export=view&id=122VXQD1cZm5YF3zJq17TAbKG4n41m8dg"
+    "image": "https://drive.google.com/uc?export=download&id=122VXQD1cZm5YF3zJq17TAbKG4n41m8dg"
   },
   {
     "id": "MA_3",
@@ -61,11 +61,11 @@
     "keyPhrase": "Позволь себе расцвести.",
     "description": "Женщина сидит в окружении природы, на фоне поля пшеницы. Символ Венеры на щите указывает на любовь и плодородие.",
     "symbolism": "Пшеница — изобилие, трон — власть, природа — материнство, подушка с сердцем — любовь.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1xefBtoKmfHJpXyf-q7muQnboOfhK9Eiu",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1NmDJgYS_kSIMbS5wyGkL9voBZPgNsGjS",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1xefBtoKmfHJpXyf-q7muQnboOfhK9Eiu",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1NmDJgYS_kSIMbS5wyGkL9voBZPgNsGjS",
     "symbol": "👑",
     "meaning": "Изобилие, материнство, природа",
-    "image": "https://drive.google.com/uc?export=view&id=1xefBtoKmfHJpXyf-q7muQnboOfhK9Eiu"
+    "image": "https://drive.google.com/uc?export=download&id=1xefBtoKmfHJpXyf-q7muQnboOfhK9Eiu"
   },
   {
     "id": "MA_4",
@@ -78,11 +78,11 @@
     "keyPhrase": "Сила в стабильности.",
     "description": "Властный мужчина на каменном троне, украшенном бараньими головами. Он держит скипетр и сферу — символы власти.",
     "symbolism": "Камень — стабильность, красный наряд — сила, баран — Овен и лидерство, трон — порядок и контроль.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1Oaz0VAhObSUr0TI6spXmVcoNtpf4mGzT",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1J9XqHptQbnJdU2fa1DU5n1Y-iXNPu8hd",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1Oaz0VAhObSUr0TI6spXmVcoNtpf4mGzT",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1J9XqHptQbnJdU2fa1DU5n1Y-iXNPu8hd",
     "symbol": "⚔️",
     "meaning": "Структура, стабильность, авторитет",
-    "image": "https://drive.google.com/uc?export=view&id=1Oaz0VAhObSUr0TI6spXmVcoNtpf4mGzT"
+    "image": "https://drive.google.com/uc?export=download&id=1Oaz0VAhObSUr0TI6spXmVcoNtpf4mGzT"
   },
   {
     "id": "MA_5",
@@ -95,11 +95,11 @@
     "keyPhrase": "Следуй мудрости поколений.",
     "description": "Пожилой человек в мантии с посохом стоит на вершине горы, освещая путь фонарём.",
     "symbolism": "Фонарь — поиск истины, посох — поддержка и мудрость, гора — путь к просветлению.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1_gRBof88K0VrL0Sylr-X_A93w0a-C09B",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=136GKTv1DgUI15oRYmuly301DyI5_PtwL",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1_gRBof88K0VrL0Sylr-X_A93w0a-C09B",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=136GKTv1DgUI15oRYmuly301DyI5_PtwL",
     "symbol": "📿",
     "meaning": "Традиции, знание, наставник",
-    "image": "https://drive.google.com/uc?export=view&id=1_gRBof88K0VrL0Sylr-X_A93w0a-C09B"
+    "image": "https://drive.google.com/uc?export=download&id=1_gRBof88K0VrL0Sylr-X_A93w0a-C09B"
   },
   {
     "id": "MA_6",
@@ -112,11 +112,11 @@
     "keyPhrase": "Сердце подскажет путь.",
     "description": "Мужчина стоит перед двумя женщинами, над ним парит ангел с распростёртыми крыльями.",
     "symbolism": "Ангел — высшее руководство, фигуры — выбор, чувства, моральные дилеммы.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1NxCaGfil5VvBKrhJGomwL5WBelH1fBei",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1uuaNuqOVjIJfFbge7OW0ucHjKVqpWyUq",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1NxCaGfil5VvBKrhJGomwL5WBelH1fBei",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1uuaNuqOVjIJfFbge7OW0ucHjKVqpWyUq",
     "symbol": "🔮",
     "meaning": "Выбор, любовь, гармония",
-    "image": "https://drive.google.com/uc?export=view&id=1NxCaGfil5VvBKrhJGomwL5WBelH1fBei"
+    "image": "https://drive.google.com/uc?export=download&id=1NxCaGfil5VvBKrhJGomwL5WBelH1fBei"
   },
   {
     "id": "MA_7",
@@ -129,11 +129,11 @@
     "keyPhrase": "Ты держишь поводья судьбы.",
     "description": "Воин в доспехах управляет колесницей, впряжённой двумя сфинксами — чёрным и белым.",
     "symbolism": "Сфинксы — дуальность, колесница — контроль и направление, звезда — победа.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=18Ch0LD3yL0lYnvTryqjo6uO0jQJJdozn",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1459s-2eCWerU3FVPNuA1dztEwCQ5EJu9",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=18Ch0LD3yL0lYnvTryqjo6uO0jQJJdozn",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1459s-2eCWerU3FVPNuA1dztEwCQ5EJu9",
     "symbol": "🏇",
     "meaning": "Победа, решимость, контроль",
-    "image": "https://drive.google.com/uc?export=view&id=18Ch0LD3yL0lYnvTryqjo6uO0jQJJdozn"
+    "image": "https://drive.google.com/uc?export=download&id=18Ch0LD3yL0lYnvTryqjo6uO0jQJJdozn"
   },
   {
     "id": "MA_8",
@@ -146,11 +146,11 @@
     "keyPhrase": "Истинная сила — в мягкости.",
     "description": "Женщина с венком на голове спокойно укрощает льва, держа его пасть открытой.",
     "symbolism": "Лев — страсть и инстинкты, женщина — внутреннее спокойствие, сила духа.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1b7N8QsS9eoDuY5M0kTcxFQZOPyNXl2dt",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1p1luoVPYrEBODbQQN02PW3VogmdM4KvV",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1b7N8QsS9eoDuY5M0kTcxFQZOPyNXl2dt",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1p1luoVPYrEBODbQQN02PW3VogmdM4KvV",
     "symbol": "🦁",
     "meaning": "Мужество, сострадание, внутренняя сила",
-    "image": "https://drive.google.com/uc?export=view&id=1b7N8QsS9eoDuY5M0kTcxFQZOPyNXl2dt"
+    "image": "https://drive.google.com/uc?export=download&id=1b7N8QsS9eoDuY5M0kTcxFQZOPyNXl2dt"
   },
   {
     "id": "MA_9",
@@ -163,11 +163,11 @@
     "keyPhrase": "Ответы приходят в тишине.",
     "description": "Мужчина висит вниз головой на перекладине, выражая смирение и просветление.",
     "symbolism": "Верёвка — добровольное подчинение, нимб — просветление, переворот — иная перспектива.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1oSfxxT8mM20v3Nekgw95kp0PRinb5Eq9",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1kEHsleLftvOn7khu0pF6nrXZqsfTOe0q",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1oSfxxT8mM20v3Nekgw95kp0PRinb5Eq9",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1kEHsleLftvOn7khu0pF6nrXZqsfTOe0q",
     "symbol": "🕯️",
     "meaning": "Поиск, мудрость, уединение",
-    "image": "https://drive.google.com/uc?export=view&id=1oSfxxT8mM20v3Nekgw95kp0PRinb5Eq9"
+    "image": "https://drive.google.com/uc?export=download&id=1oSfxxT8mM20v3Nekgw95kp0PRinb5Eq9"
   },
   {
     "id": "MA_10",
@@ -180,11 +180,11 @@
     "keyPhrase": "Всё меняется — прими поворот.",
     "description": "Колесо с мифическими существами вращается в облаках, символизируя перемены.",
     "symbolism": "Колесо — циклы судьбы, сфинкс — знание, змей — неизбежность перемен.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1M_CWINMmksX4bIDRe2AcigTK-q9ctNZ3",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=13_DqBGXsIDRWUYiQ9QrG964fNkoclUTx",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1M_CWINMmksX4bIDRe2AcigTK-q9ctNZ3",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=13_DqBGXsIDRWUYiQ9QrG964fNkoclUTx",
     "symbol": "🎡",
     "meaning": "Удача, циклы, судьба",
-    "image": "https://drive.google.com/uc?export=view&id=1M_CWINMmksX4bIDRe2AcigTK-q9ctNZ3"
+    "image": "https://drive.google.com/uc?export=download&id=1M_CWINMmksX4bIDRe2AcigTK-q9ctNZ3"
   },
   {
     "id": "MA_11",
@@ -197,11 +197,11 @@
     "keyPhrase": "Что посеешь — то и пожнёшь.",
     "description": "Судья с повязкой на глазах держит меч и весы, восседая между двух колонн.",
     "symbolism": "Меч — правда, весы — справедливость, повязка — беспристрастность.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=178euUzuenf-tEQH5YrBDSUgMiCWufq_P",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1RAgTpkrhFAYLLPSMMIesP0ECImqdbzj3",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=178euUzuenf-tEQH5YrBDSUgMiCWufq_P",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1RAgTpkrhFAYLLPSMMIesP0ECImqdbzj3",
     "symbol": "🔮",
     "meaning": "Честность, справедливость, карма",
-    "image": "https://drive.google.com/uc?export=view&id=178euUzuenf-tEQH5YrBDSUgMiCWufq_P"
+    "image": "https://drive.google.com/uc?export=download&id=178euUzuenf-tEQH5YrBDSUgMiCWufq_P"
   },
   {
     "id": "MA_12",
@@ -214,11 +214,11 @@
     "keyPhrase": "Иногда нужно отпустить.",
     "description": "Фигура в капюшоне направляется по тёмной тропе к свету на горизонте.",
     "symbolism": "Путь — трансформация, вода — подсознание, капюшон — скрытие прошлого.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=18gctZUaDLc5XoAqG7IHhp6YmNIr0SQ-S",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1sKWwoKw1kd7aTfP1p9ycv_b3MljK_a21",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=18gctZUaDLc5XoAqG7IHhp6YmNIr0SQ-S",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1sKWwoKw1kd7aTfP1p9ycv_b3MljK_a21",
     "symbol": "🙃",
     "meaning": "Пауза, взгляд со стороны, жертва",
-    "image": "https://drive.google.com/uc?export=view&id=18gctZUaDLc5XoAqG7IHhp6YmNIr0SQ-S"
+    "image": "https://drive.google.com/uc?export=download&id=18gctZUaDLc5XoAqG7IHhp6YmNIr0SQ-S"
   },
   {
     "id": "MA_13",
@@ -231,11 +231,11 @@
     "keyPhrase": "Старое уходит — дай место новому.",
     "description": "Скелет в доспехах едет на белом коне, пересекая тела короля, священника и ребёнка.",
     "symbolism": "Скелет — перемены, белый конь — чистота, павшие фигуры — неизбежность.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1E2pBZD4Js6KiBgM2EQleavJJfBIRq1N1",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1OufX_q3Bded-bLSLHwjgstKujQc2PLnE",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1E2pBZD4Js6KiBgM2EQleavJJfBIRq1N1",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1OufX_q3Bded-bLSLHwjgstKujQc2PLnE",
     "symbol": "💀",
     "meaning": "Конец, трансформация, перерождение",
-    "image": "https://drive.google.com/uc?export=view&id=1E2pBZD4Js6KiBgM2EQleavJJfBIRq1N1"
+    "image": "https://drive.google.com/uc?export=download&id=1E2pBZD4Js6KiBgM2EQleavJJfBIRq1N1"
   },
   {
     "id": "MA_14",
@@ -248,11 +248,11 @@
     "keyPhrase": "Гармония во всём.",
     "description": "Ангел переливает воду из одного кубка в другой, стоя с одной ногой в воде.",
     "symbolism": "Кубки — баланс, вода — эмоции, огненный фон — гармония стихий.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1JdeH1qd5JPtbV98ORbC_kqVdy-THVnAZ",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1yOacXtlnDqo4vyUrwaPw1VD24Dz6zg7i",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1JdeH1qd5JPtbV98ORbC_kqVdy-THVnAZ",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1yOacXtlnDqo4vyUrwaPw1VD24Dz6zg7i",
     "symbol": "🍷",
     "meaning": "Баланс, исцеление, терпение",
-    "image": "https://drive.google.com/uc?export=view&id=1JdeH1qd5JPtbV98ORbC_kqVdy-THVnAZ"
+    "image": "https://drive.google.com/uc?export=download&id=1JdeH1qd5JPtbV98ORbC_kqVdy-THVnAZ"
   },
   {
     "id": "MA_15",
@@ -265,11 +265,11 @@
     "keyPhrase": "Что тебя сдерживает?",
     "description": "Дьявол восседает на пьедестале, перед ним закованные в цепи мужчина и женщина.",
     "symbolism": "Цепи — зависимости, рога — искушения, фигуры — подчинение страстям.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=12YUkItwOzEAcroEkLRVJe330WFf2SvN-",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1DeEwHaXxB3_L6C7sl4KpsVXXX1J5Z-sb",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=12YUkItwOzEAcroEkLRVJe330WFf2SvN-",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1DeEwHaXxB3_L6C7sl4KpsVXXX1J5Z-sb",
     "symbol": "😈",
     "meaning": "Привязанность, соблазн, тень",
-    "image": "https://drive.google.com/uc?export=view&id=12YUkItwOzEAcroEkLRVJe330WFf2SvN-"
+    "image": "https://drive.google.com/uc?export=download&id=12YUkItwOzEAcroEkLRVJe330WFf2SvN-"
   },
   {
     "id": "MA_16",
@@ -282,11 +282,11 @@
     "keyPhrase": "Сломай, чтобы построить.",
     "description": "Башня поражена молнией, люди падают с неё в ужасе, огонь охватывает здание.",
     "symbolism": "Башня — гордыня, молния — внезапное разрушение, падение — освобождение.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1HTCmpeTUcEB67fLSIaA2TA-SD7J7YRol",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1z6fONjo3Z91PzITYGwMGPozTUGS6IWrp",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1HTCmpeTUcEB67fLSIaA2TA-SD7J7YRol",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1z6fONjo3Z91PzITYGwMGPozTUGS6IWrp",
     "symbol": "🏗️",
     "meaning": "Разрушение, потрясение, истина",
-    "image": "https://drive.google.com/uc?export=view&id=1HTCmpeTUcEB67fLSIaA2TA-SD7J7YRol"
+    "image": "https://drive.google.com/uc?export=download&id=1HTCmpeTUcEB67fLSIaA2TA-SD7J7YRol"
   },
   {
     "id": "MA_17",
@@ -299,11 +299,11 @@
     "keyPhrase": "Свет в конце тоннеля.",
     "description": "Нагая женщина льёт воду из двух кувшинов под звёздным небом, одна нога в воде.",
     "symbolism": "Звезда — надежда, кувшины — вдохновение, вода — духовное очищение.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1d6YNPOVA8mFKiML94vzDjVJVZLBXfgoV",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1DvVyz0U4Ez55j03Iolitk0eiybQtgB6Q",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1d6YNPOVA8mFKiML94vzDjVJVZLBXfgoV",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1DvVyz0U4Ez55j03Iolitk0eiybQtgB6Q",
     "symbol": "⭐",
     "meaning": "Надежда, вдохновение, исцеление",
-    "image": "https://drive.google.com/uc?export=view&id=1d6YNPOVA8mFKiML94vzDjVJVZLBXfgoV"
+    "image": "https://drive.google.com/uc?export=download&id=1d6YNPOVA8mFKiML94vzDjVJVZLBXfgoV"
   },
   {
     "id": "MA_18",
@@ -316,11 +316,11 @@
     "keyPhrase": "Не всё так, как кажется.",
     "description": "Дорога между двумя башнями ведёт к луне, собака и волк воют, рак выходит из воды.",
     "symbolism": "Луна — иллюзии, животные — инстинкты, путь — внутреннее путешествие.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1ti6Tj5kaPxJbwwUUthMogA16VG2XGsv0",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1zuSAUkk5MaVjoj1cLWeOVyHebO1NpHCH",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1ti6Tj5kaPxJbwwUUthMogA16VG2XGsv0",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1zuSAUkk5MaVjoj1cLWeOVyHebO1NpHCH",
     "symbol": "🌙",
     "meaning": "Иллюзии, интуиция, страхи",
-    "image": "https://drive.google.com/uc?export=view&id=1ti6Tj5kaPxJbwwUUthMogA16VG2XGsv0"
+    "image": "https://drive.google.com/uc?export=download&id=1ti6Tj5kaPxJbwwUUthMogA16VG2XGsv0"
   },
   {
     "id": "MA_19",
@@ -333,11 +333,11 @@
     "keyPhrase": "Сияй — ты заслужил(а)!",
     "description": "Ребёнок едет на белом коне под сияющим солнцем, позади — стена с подсолнухами.",
     "symbolism": "Солнце — счастье, ребёнок — невинность, белый конь — чистота, подсолнухи — рост.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1J3el81wXxlyXS07Bj3ikSgzvn1LKI-kL",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=12enMFRKALRHmuL98paIYyZTFbXX8r_L1",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1J3el81wXxlyXS07Bj3ikSgzvn1LKI-kL",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=12enMFRKALRHmuL98paIYyZTFbXX8r_L1",
     "symbol": "☀️",
     "meaning": "Радость, успех, жизненная сила",
-    "image": "https://drive.google.com/uc?export=view&id=1J3el81wXxlyXS07Bj3ikSgzvn1LKI-kL"
+    "image": "https://drive.google.com/uc?export=download&id=1J3el81wXxlyXS07Bj3ikSgzvn1LKI-kL"
   },
   {
     "id": "MA_20",
@@ -350,11 +350,11 @@
     "keyPhrase": "Время — действовать по совести.",
     "description": "Ангел трубит в рог, мёртвые восстают из гробов, протягивая руки к небу.",
     "symbolism": "Труба — пробуждение, фигуры — возрождение, небо — высший суд.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=16mhn7_6aKDZSYAjYOWPeCAMoroMZGw4p",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1jevGSRZV0xe7tW9Mmkf6bLYtwjeEMWC5",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=16mhn7_6aKDZSYAjYOWPeCAMoroMZGw4p",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1jevGSRZV0xe7tW9Mmkf6bLYtwjeEMWC5",
     "symbol": "📯",
     "meaning": "Пробуждение, прощение, возрождение",
-    "image": "https://drive.google.com/uc?export=view&id=16mhn7_6aKDZSYAjYOWPeCAMoroMZGw4p"
+    "image": "https://drive.google.com/uc?export=download&id=16mhn7_6aKDZSYAjYOWPeCAMoroMZGw4p"
   },
   {
     "id": "MA_21",
@@ -367,11 +367,11 @@
     "keyPhrase": "Ты дошёл до конца пути.",
     "description": "Женщина танцует в венке из лавра, окружённая четырьмя существами — символами стихий.",
     "symbolism": "Лавр — завершение, венок — успех, существа — стабильность и равновесие.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1PFEuGi5ICimU0wz-lYlu42k1vbGB_1wg",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1qug-CJkT9kUlWrWBR0Z2EEZXfZ0IBAm9",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1PFEuGi5ICimU0wz-lYlu42k1vbGB_1wg",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1qug-CJkT9kUlWrWBR0Z2EEZXfZ0IBAm9",
     "symbol": "🌍",
     "meaning": "Завершение, успех, целостность",
-    "image": "https://drive.google.com/uc?export=view&id=1PFEuGi5ICimU0wz-lYlu42k1vbGB_1wg"
+    "image": "https://drive.google.com/uc?export=download&id=1PFEuGi5ICimU0wz-lYlu42k1vbGB_1wg"
   },
   {
     "id": "Ж_1",
@@ -384,11 +384,11 @@
     "keyPhrase": "Начало — энергия масти жезлы",
     "description": "Рука, выходящая из облака, держит символ масти на фоне пейзажа.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1_FhW4qTsq-aqGi0vxyB6-lc2UYo1L0Xk",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1aoSI1yvF0TO34MQ42jThRqPl9KNkDX95",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1_FhW4qTsq-aqGi0vxyB6-lc2UYo1L0Xk",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1aoSI1yvF0TO34MQ42jThRqPl9KNkDX95",
     "symbol": "🔮",
     "meaning": "Начало",
-    "image": "https://drive.google.com/uc?export=view&id=1_FhW4qTsq-aqGi0vxyB6-lc2UYo1L0Xk"
+    "image": "https://drive.google.com/uc?export=download&id=1_FhW4qTsq-aqGi0vxyB6-lc2UYo1L0Xk"
   },
   {
     "id": "Ж_2",
@@ -401,11 +401,11 @@
     "keyPhrase": "Партнёрство — энергия масти жезлы",
     "description": "Две фигуры или объекта отражают тему партнёрства или выбора.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1B8egUbfBoBZQ61w-iPzpf5uXutv8mvlc",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1DRScae23rE9viFNp2ZI2HW0xV4eAiqws",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1B8egUbfBoBZQ61w-iPzpf5uXutv8mvlc",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1DRScae23rE9viFNp2ZI2HW0xV4eAiqws",
     "symbol": "🔮",
     "meaning": "Партнёрство",
-    "image": "https://drive.google.com/uc?export=view&id=1B8egUbfBoBZQ61w-iPzpf5uXutv8mvlc"
+    "image": "https://drive.google.com/uc?export=download&id=1B8egUbfBoBZQ61w-iPzpf5uXutv8mvlc"
   },
   {
     "id": "Ж_3",
@@ -418,11 +418,11 @@
     "keyPhrase": "Рост — энергия масти жезлы",
     "description": "Три элемента указывают на начало роста и взаимодействие.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1Hm8GZ_GdmoC4fHcyam4YckrcD3zk_S2P",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1Kt7ylMoq98_dMOr1iGpZDQ1vABW6pI2W",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1Hm8GZ_GdmoC4fHcyam4YckrcD3zk_S2P",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1Kt7ylMoq98_dMOr1iGpZDQ1vABW6pI2W",
     "symbol": "🔮",
     "meaning": "Рост",
-    "image": "https://drive.google.com/uc?export=view&id=1Hm8GZ_GdmoC4fHcyam4YckrcD3zk_S2P"
+    "image": "https://drive.google.com/uc?export=download&id=1Hm8GZ_GdmoC4fHcyam4YckrcD3zk_S2P"
   },
   {
     "id": "Ж_4",
@@ -435,11 +435,11 @@
     "keyPhrase": "Стабильность — энергия масти жезлы",
     "description": "Стабильная сцена с символами масти, символизирующая покой или застой.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=10mE9PaZLAjffulVVF3Dj-EuSQbk7xm-1",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1Z55DtpnUmYH6I11XyCtXylGApAOnfsaZ",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=10mE9PaZLAjffulVVF3Dj-EuSQbk7xm-1",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1Z55DtpnUmYH6I11XyCtXylGApAOnfsaZ",
     "symbol": "🔮",
     "meaning": "Стабильность",
-    "image": "https://drive.google.com/uc?export=view&id=10mE9PaZLAjffulVVF3Dj-EuSQbk7xm-1"
+    "image": "https://drive.google.com/uc?export=download&id=10mE9PaZLAjffulVVF3Dj-EuSQbk7xm-1"
   },
   {
     "id": "Ж_5",
@@ -452,11 +452,11 @@
     "keyPhrase": "Конфликт — энергия масти жезлы",
     "description": "Изображение потерь, конфликта или нестабильности.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1bnfsUYyOC8S1-S-RRPD1bZ8GQ8QW5cuf",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1q7_BXI0GPh3tNG-YuKEHeNZtvh7_bkGU",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1bnfsUYyOC8S1-S-RRPD1bZ8GQ8QW5cuf",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1q7_BXI0GPh3tNG-YuKEHeNZtvh7_bkGU",
     "symbol": "🔮",
     "meaning": "Конфликт",
-    "image": "https://drive.google.com/uc?export=view&id=1bnfsUYyOC8S1-S-RRPD1bZ8GQ8QW5cuf"
+    "image": "https://drive.google.com/uc?export=download&id=1bnfsUYyOC8S1-S-RRPD1bZ8GQ8QW5cuf"
   },
   {
     "id": "Ж_6",
@@ -469,11 +469,11 @@
     "keyPhrase": "Переход — энергия масти жезлы",
     "description": "Гармоничная сцена, связанная с дарением, воспоминаниями или помощью.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1vGaQGB1qnbUkKUPqn8jFou-TLMTgUjtJ",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1w6MSSUGDAjEwMCvWIrxh5Wj41JoQvmj3",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1vGaQGB1qnbUkKUPqn8jFou-TLMTgUjtJ",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1w6MSSUGDAjEwMCvWIrxh5Wj41JoQvmj3",
     "symbol": "🔮",
     "meaning": "Переход",
-    "image": "https://drive.google.com/uc?export=view&id=1vGaQGB1qnbUkKUPqn8jFou-TLMTgUjtJ"
+    "image": "https://drive.google.com/uc?export=download&id=1vGaQGB1qnbUkKUPqn8jFou-TLMTgUjtJ"
   },
   {
     "id": "Ж_7",
@@ -486,11 +486,11 @@
     "keyPhrase": "Вызов — энергия масти жезлы",
     "description": "Выбор среди множества, хаос или переизбыток.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1aJiVf-CxrykrXPYuF7jC2ZDKyIgRa1Mp",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=13EPqyelsYHbgVyRbdkaRy9wu6lHRj6n7",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1aJiVf-CxrykrXPYuF7jC2ZDKyIgRa1Mp",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=13EPqyelsYHbgVyRbdkaRy9wu6lHRj6n7",
     "symbol": "🔮",
     "meaning": "Вызов",
-    "image": "https://drive.google.com/uc?export=view&id=1aJiVf-CxrykrXPYuF7jC2ZDKyIgRa1Mp"
+    "image": "https://drive.google.com/uc?export=download&id=1aJiVf-CxrykrXPYuF7jC2ZDKyIgRa1Mp"
   },
   {
     "id": "Ж_8",
@@ -503,11 +503,11 @@
     "keyPhrase": "Движение — энергия масти жезлы",
     "description": "Движение прочь, уход или отстранение.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1Z9-JdIzDQuzUVmUS0u5YcKeS7mHqAlW_",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1mph4p0LTFXa93ah0D8EoDyaQLptGHGTQ",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1Z9-JdIzDQuzUVmUS0u5YcKeS7mHqAlW_",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1mph4p0LTFXa93ah0D8EoDyaQLptGHGTQ",
     "symbol": "🔮",
     "meaning": "Движение",
-    "image": "https://drive.google.com/uc?export=view&id=1Z9-JdIzDQuzUVmUS0u5YcKeS7mHqAlW_"
+    "image": "https://drive.google.com/uc?export=download&id=1Z9-JdIzDQuzUVmUS0u5YcKeS7mHqAlW_"
   },
   {
     "id": "Ж_9",
@@ -520,11 +520,11 @@
     "keyPhrase": "Испытания — энергия масти жезлы",
     "description": "Достижение, комфорт или тревожное удовлетворение.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1oqeNgv31yuA82nzVKXhSt0G5qBXWk8pY",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1M4Zkl1tPn_W9QL4HqFOchjHjz1metYXX",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1oqeNgv31yuA82nzVKXhSt0G5qBXWk8pY",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1M4Zkl1tPn_W9QL4HqFOchjHjz1metYXX",
     "symbol": "🔮",
     "meaning": "Испытания",
-    "image": "https://drive.google.com/uc?export=view&id=1oqeNgv31yuA82nzVKXhSt0G5qBXWk8pY"
+    "image": "https://drive.google.com/uc?export=download&id=1oqeNgv31yuA82nzVKXhSt0G5qBXWk8pY"
   },
   {
     "id": "Ж_10",
@@ -537,11 +537,11 @@
     "keyPhrase": "Бремя — энергия масти жезлы",
     "description": "Завершение, крайняя форма масти — как позитивная, так и тяжёлая.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=13wRAulnJjy4majrkTDTjdxp7as8Xn8o7",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=18Ow7Ui-7Ed4-pKYXN0t2r9XOcNIKRUdY",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=13wRAulnJjy4majrkTDTjdxp7as8Xn8o7",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=18Ow7Ui-7Ed4-pKYXN0t2r9XOcNIKRUdY",
     "symbol": "🔮",
     "meaning": "Бремя",
-    "image": "https://drive.google.com/uc?export=view&id=13wRAulnJjy4majrkTDTjdxp7as8Xn8o7"
+    "image": "https://drive.google.com/uc?export=download&id=13wRAulnJjy4majrkTDTjdxp7as8Xn8o7"
   },
   {
     "id": "Ж_11",
@@ -554,11 +554,11 @@
     "keyPhrase": "Весть — энергия масти жезлы",
     "description": "Молодой человек, держащий символ масти, полон любопытства.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1JBpJuFbF9ulM3umLbdhZifJyuR_5JxHA",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1RBlongfWYIqufj7J3nbmLsBPRFyAeG1O",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1JBpJuFbF9ulM3umLbdhZifJyuR_5JxHA",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1RBlongfWYIqufj7J3nbmLsBPRFyAeG1O",
     "symbol": "🔮",
     "meaning": "Весть",
-    "image": "https://drive.google.com/uc?export=view&id=1JBpJuFbF9ulM3umLbdhZifJyuR_5JxHA"
+    "image": "https://drive.google.com/uc?export=download&id=1JBpJuFbF9ulM3umLbdhZifJyuR_5JxHA"
   },
   {
     "id": "Ж_12",
@@ -571,11 +571,11 @@
     "keyPhrase": "Действие — энергия масти жезлы",
     "description": "Воин на коне с символом масти, устремлённый вперёд.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1HZlfGiQbcOwlIo0Jmq0ifig8IhsiXp9e",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1YrwlNws5xM3E-HimGEcXwe8HODIdjm2a",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1HZlfGiQbcOwlIo0Jmq0ifig8IhsiXp9e",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1YrwlNws5xM3E-HimGEcXwe8HODIdjm2a",
     "symbol": "🔮",
     "meaning": "Действие",
-    "image": "https://drive.google.com/uc?export=view&id=1HZlfGiQbcOwlIo0Jmq0ifig8IhsiXp9e"
+    "image": "https://drive.google.com/uc?export=download&id=1HZlfGiQbcOwlIo0Jmq0ifig8IhsiXp9e"
   },
   {
     "id": "Ж_13",
@@ -588,11 +588,11 @@
     "keyPhrase": "Забота — энергия масти жезлы",
     "description": "Женская фигура, олицетворяющая зрелость масти.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1hIVSrMJOnr2_krhRco34gD9GZkSpF5NC",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1TsOQ9VbYI8RVOJsLmCe7lzaBMc807Qcz",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1hIVSrMJOnr2_krhRco34gD9GZkSpF5NC",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1TsOQ9VbYI8RVOJsLmCe7lzaBMc807Qcz",
     "symbol": "🔮",
     "meaning": "Забота",
-    "image": "https://drive.google.com/uc?export=view&id=1hIVSrMJOnr2_krhRco34gD9GZkSpF5NC"
+    "image": "https://drive.google.com/uc?export=download&id=1hIVSrMJOnr2_krhRco34gD9GZkSpF5NC"
   },
   {
     "id": "Ж_14",
@@ -605,11 +605,11 @@
     "keyPhrase": "Зрелость — энергия масти жезлы",
     "description": "Мужская фигура, управляющая силой масти с уверенностью.",
     "symbolism": "Жезлы — энергия, действия, страсть. Пейзажи сухие или холмистые.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=12BAriSLUg_kUQeQGpizvA0BSnx1c4Hll",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1wWGtuR28JHhpxSdBu0YX8OelSQA4HWKP",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=12BAriSLUg_kUQeQGpizvA0BSnx1c4Hll",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1wWGtuR28JHhpxSdBu0YX8OelSQA4HWKP",
     "symbol": "🔮",
     "meaning": "Зрелость",
-    "image": "https://drive.google.com/uc?export=view&id=12BAriSLUg_kUQeQGpizvA0BSnx1c4Hll"
+    "image": "https://drive.google.com/uc?export=download&id=12BAriSLUg_kUQeQGpizvA0BSnx1c4Hll"
   },
   {
     "id": "К_1",
@@ -622,11 +622,11 @@
     "keyPhrase": "Начало — энергия масти кубки",
     "description": "Рука, выходящая из облака, держит символ масти на фоне пейзажа.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1ibfsjLweRCRoXSUP5JiUHg26GNYF3aRb",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1USkvN-zpu4vzpq13Q0glEwj944WbR-XX",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1ibfsjLweRCRoXSUP5JiUHg26GNYF3aRb",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1USkvN-zpu4vzpq13Q0glEwj944WbR-XX",
     "symbol": "🔮",
     "meaning": "Начало",
-    "image": "https://drive.google.com/uc?export=view&id=1ibfsjLweRCRoXSUP5JiUHg26GNYF3aRb"
+    "image": "https://drive.google.com/uc?export=download&id=1ibfsjLweRCRoXSUP5JiUHg26GNYF3aRb"
   },
   {
     "id": "К_2",
@@ -639,11 +639,11 @@
     "keyPhrase": "Партнёрство — энергия масти кубки",
     "description": "Две фигуры или объекта отражают тему партнёрства или выбора.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1Mst1vV1dYYmKSBc7YTrcyvqCzjb_Mw28",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1FgUyZLRtOqXmkNDlkDGxg3ihzx8kXIR1",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1Mst1vV1dYYmKSBc7YTrcyvqCzjb_Mw28",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1FgUyZLRtOqXmkNDlkDGxg3ihzx8kXIR1",
     "symbol": "🔮",
     "meaning": "Партнёрство",
-    "image": "https://drive.google.com/uc?export=view&id=1Mst1vV1dYYmKSBc7YTrcyvqCzjb_Mw28"
+    "image": "https://drive.google.com/uc?export=download&id=1Mst1vV1dYYmKSBc7YTrcyvqCzjb_Mw28"
   },
   {
     "id": "К_3",
@@ -656,11 +656,11 @@
     "keyPhrase": "Рост — энергия масти кубки",
     "description": "Три элемента указывают на начало роста и взаимодействие.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=15orR3e8nkfK-KeOo2knylQ6eAsK4IZZg",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1AI62wX4JNDOOmplTtzVQ1b1mFw9_hUsF",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=15orR3e8nkfK-KeOo2knylQ6eAsK4IZZg",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1AI62wX4JNDOOmplTtzVQ1b1mFw9_hUsF",
     "symbol": "🔮",
     "meaning": "Рост",
-    "image": "https://drive.google.com/uc?export=view&id=15orR3e8nkfK-KeOo2knylQ6eAsK4IZZg"
+    "image": "https://drive.google.com/uc?export=download&id=15orR3e8nkfK-KeOo2knylQ6eAsK4IZZg"
   },
   {
     "id": "К_4",
@@ -673,11 +673,11 @@
     "keyPhrase": "Стабильность — энергия масти кубки",
     "description": "Стабильная сцена с символами масти, символизирующая покой или застой.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1kSGMo2H0_gs2hvXqLsBpZ7zw43cLIhLa",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1G-QIamLEDt74HEx2QE1Ah9l6gaIiQ0BU",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1kSGMo2H0_gs2hvXqLsBpZ7zw43cLIhLa",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1G-QIamLEDt74HEx2QE1Ah9l6gaIiQ0BU",
     "symbol": "🔮",
     "meaning": "Стабильность",
-    "image": "https://drive.google.com/uc?export=view&id=1kSGMo2H0_gs2hvXqLsBpZ7zw43cLIhLa"
+    "image": "https://drive.google.com/uc?export=download&id=1kSGMo2H0_gs2hvXqLsBpZ7zw43cLIhLa"
   },
   {
     "id": "К_5",
@@ -690,11 +690,11 @@
     "keyPhrase": "Конфликт — энергия масти кубки",
     "description": "Изображение потерь, конфликта или нестабильности.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1ijUt8AOuqTsRYdhJCzgNjJwW40omBZKa",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1si6pCHhHniYqbYBDDRu5dwAwT0d93n6_",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1ijUt8AOuqTsRYdhJCzgNjJwW40omBZKa",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1si6pCHhHniYqbYBDDRu5dwAwT0d93n6_",
     "symbol": "🔮",
     "meaning": "Конфликт",
-    "image": "https://drive.google.com/uc?export=view&id=1ijUt8AOuqTsRYdhJCzgNjJwW40omBZKa"
+    "image": "https://drive.google.com/uc?export=download&id=1ijUt8AOuqTsRYdhJCzgNjJwW40omBZKa"
   },
   {
     "id": "К_6",
@@ -707,11 +707,11 @@
     "keyPhrase": "Переход — энергия масти кубки",
     "description": "Гармоничная сцена, связанная с дарением, воспоминаниями или помощью.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1jcp400d8oHwCpdXbxNoOO59kg7gb9Lxz",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1_2Vka0kNeacNqXuK9r7i-_98ctlvv4HK",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1jcp400d8oHwCpdXbxNoOO59kg7gb9Lxz",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1_2Vka0kNeacNqXuK9r7i-_98ctlvv4HK",
     "symbol": "🔮",
     "meaning": "Переход",
-    "image": "https://drive.google.com/uc?export=view&id=1jcp400d8oHwCpdXbxNoOO59kg7gb9Lxz"
+    "image": "https://drive.google.com/uc?export=download&id=1jcp400d8oHwCpdXbxNoOO59kg7gb9Lxz"
   },
   {
     "id": "К_7",
@@ -724,11 +724,11 @@
     "keyPhrase": "Вызов — энергия масти кубки",
     "description": "Выбор среди множества, хаос или переизбыток.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=144sH2cBbH69L2KJPAiUi9jhmkXRnBJEH",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1ahuNfceus6vcMXNDSWpcxsspWbxO9uZC",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=144sH2cBbH69L2KJPAiUi9jhmkXRnBJEH",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1ahuNfceus6vcMXNDSWpcxsspWbxO9uZC",
     "symbol": "🔮",
     "meaning": "Вызов",
-    "image": "https://drive.google.com/uc?export=view&id=144sH2cBbH69L2KJPAiUi9jhmkXRnBJEH"
+    "image": "https://drive.google.com/uc?export=download&id=144sH2cBbH69L2KJPAiUi9jhmkXRnBJEH"
   },
   {
     "id": "К_8",
@@ -741,11 +741,11 @@
     "keyPhrase": "Движение — энергия масти кубки",
     "description": "Движение прочь, уход или отстранение.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=18NpfV8LQPuyvV-Sqgi2PbUE2kfU4lsWv",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1fv4EvhI_rcXNadknn6QAeW0ni4gqkuiZ",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=18NpfV8LQPuyvV-Sqgi2PbUE2kfU4lsWv",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1fv4EvhI_rcXNadknn6QAeW0ni4gqkuiZ",
     "symbol": "🔮",
     "meaning": "Движение",
-    "image": "https://drive.google.com/uc?export=view&id=18NpfV8LQPuyvV-Sqgi2PbUE2kfU4lsWv"
+    "image": "https://drive.google.com/uc?export=download&id=18NpfV8LQPuyvV-Sqgi2PbUE2kfU4lsWv"
   },
   {
     "id": "К_9",
@@ -758,11 +758,11 @@
     "keyPhrase": "Испытания — энергия масти кубки",
     "description": "Достижение, комфорт или тревожное удовлетворение.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1OZTHH7UgTb1X5Dig6v1MT6RjtUMrsm05",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1IHtYad_8fZsX2ghiOmsOD7nNAzVJXSrX",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1OZTHH7UgTb1X5Dig6v1MT6RjtUMrsm05",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1IHtYad_8fZsX2ghiOmsOD7nNAzVJXSrX",
     "symbol": "🔮",
     "meaning": "Испытания",
-    "image": "https://drive.google.com/uc?export=view&id=1OZTHH7UgTb1X5Dig6v1MT6RjtUMrsm05"
+    "image": "https://drive.google.com/uc?export=download&id=1OZTHH7UgTb1X5Dig6v1MT6RjtUMrsm05"
   },
   {
     "id": "К_10",
@@ -775,11 +775,11 @@
     "keyPhrase": "Бремя — энергия масти кубки",
     "description": "Завершение, крайняя форма масти — как позитивная, так и тяжёлая.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1Nh52WHmIUIHp--EaCsIilNYx6vqqwvH_",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1cLKe2tzd41u1fmFm6ssgEhoYtKrsbdqZ",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1Nh52WHmIUIHp--EaCsIilNYx6vqqwvH_",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1cLKe2tzd41u1fmFm6ssgEhoYtKrsbdqZ",
     "symbol": "🔮",
     "meaning": "Бремя",
-    "image": "https://drive.google.com/uc?export=view&id=1Nh52WHmIUIHp--EaCsIilNYx6vqqwvH_"
+    "image": "https://drive.google.com/uc?export=download&id=1Nh52WHmIUIHp--EaCsIilNYx6vqqwvH_"
   },
   {
     "id": "К_11",
@@ -792,11 +792,11 @@
     "keyPhrase": "Весть — энергия масти кубки",
     "description": "Молодой человек, держащий символ масти, полон любопытства.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1VcffSeJ7Kc5wlW8J7Nuu_QgA9w3AADFO",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1XhTK40DNkuiVhuk9ZdAMrVOG48-XKQhI",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1VcffSeJ7Kc5wlW8J7Nuu_QgA9w3AADFO",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1XhTK40DNkuiVhuk9ZdAMrVOG48-XKQhI",
     "symbol": "🔮",
     "meaning": "Весть",
-    "image": "https://drive.google.com/uc?export=view&id=1VcffSeJ7Kc5wlW8J7Nuu_QgA9w3AADFO"
+    "image": "https://drive.google.com/uc?export=download&id=1VcffSeJ7Kc5wlW8J7Nuu_QgA9w3AADFO"
   },
   {
     "id": "К_12",
@@ -809,11 +809,11 @@
     "keyPhrase": "Действие — энергия масти кубки",
     "description": "Воин на коне с символом масти, устремлённый вперёд.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1_LAkmr8Ql3ZO1tDmmkaX6Sx-fBQ6Zpko",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1a07aNpwcTy3ycxwY_NJciw4zZim_fomE",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1_LAkmr8Ql3ZO1tDmmkaX6Sx-fBQ6Zpko",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1a07aNpwcTy3ycxwY_NJciw4zZim_fomE",
     "symbol": "🔮",
     "meaning": "Действие",
-    "image": "https://drive.google.com/uc?export=view&id=1_LAkmr8Ql3ZO1tDmmkaX6Sx-fBQ6Zpko"
+    "image": "https://drive.google.com/uc?export=download&id=1_LAkmr8Ql3ZO1tDmmkaX6Sx-fBQ6Zpko"
   },
   {
     "id": "К_13",
@@ -826,11 +826,11 @@
     "keyPhrase": "Забота — энергия масти кубки",
     "description": "Женская фигура, олицетворяющая зрелость масти.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1K1MYHID9ssIbSJf0_JsrJGrL6Qx9_sJN",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1QnxdaQyxkFSSKehfL3xQADrxElS4yFcQ",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1K1MYHID9ssIbSJf0_JsrJGrL6Qx9_sJN",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1QnxdaQyxkFSSKehfL3xQADrxElS4yFcQ",
     "symbol": "🔮",
     "meaning": "Забота",
-    "image": "https://drive.google.com/uc?export=view&id=1K1MYHID9ssIbSJf0_JsrJGrL6Qx9_sJN"
+    "image": "https://drive.google.com/uc?export=download&id=1K1MYHID9ssIbSJf0_JsrJGrL6Qx9_sJN"
   },
   {
     "id": "К_14",
@@ -843,11 +843,11 @@
     "keyPhrase": "Зрелость — энергия масти кубки",
     "description": "Мужская фигура, управляющая силой масти с уверенностью.",
     "symbolism": "Кубки — эмоции, отношения, вода. Часто изображаются реки или озёра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1LmRPJ-XpL2xB-ycY4P4HIgsgVKZf1Pdf",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1W2ff26XNsjQ0LKpMIghtQVt-nDc_pAp2",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1LmRPJ-XpL2xB-ycY4P4HIgsgVKZf1Pdf",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1W2ff26XNsjQ0LKpMIghtQVt-nDc_pAp2",
     "symbol": "🔮",
     "meaning": "Зрелость",
-    "image": "https://drive.google.com/uc?export=view&id=1LmRPJ-XpL2xB-ycY4P4HIgsgVKZf1Pdf"
+    "image": "https://drive.google.com/uc?export=download&id=1LmRPJ-XpL2xB-ycY4P4HIgsgVKZf1Pdf"
   },
   {
     "id": "М_1",
@@ -860,11 +860,11 @@
     "keyPhrase": "Начало — энергия масти мечи",
     "description": "Рука, выходящая из облака, держит символ масти на фоне пейзажа.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1B2MN3TNld44M8IzzkGFbhY7aCGVAZ_AZ",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=19nDcNHP02WgdNLqurqETQYWgeb86JWId",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1B2MN3TNld44M8IzzkGFbhY7aCGVAZ_AZ",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=19nDcNHP02WgdNLqurqETQYWgeb86JWId",
     "symbol": "🔮",
     "meaning": "Начало",
-    "image": "https://drive.google.com/uc?export=view&id=1B2MN3TNld44M8IzzkGFbhY7aCGVAZ_AZ"
+    "image": "https://drive.google.com/uc?export=download&id=1B2MN3TNld44M8IzzkGFbhY7aCGVAZ_AZ"
   },
   {
     "id": "М_2",
@@ -877,11 +877,11 @@
     "keyPhrase": "Партнёрство — энергия масти мечи",
     "description": "Две фигуры или объекта отражают тему партнёрства или выбора.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1rXHaUKHsahAu8hTAJ6fgXJvSLK2LBuGl",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=12cQu_dXyBw94L_QKEd6FrxV0G4e5YpiP",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1rXHaUKHsahAu8hTAJ6fgXJvSLK2LBuGl",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=12cQu_dXyBw94L_QKEd6FrxV0G4e5YpiP",
     "symbol": "🔮",
     "meaning": "Партнёрство",
-    "image": "https://drive.google.com/uc?export=view&id=1rXHaUKHsahAu8hTAJ6fgXJvSLK2LBuGl"
+    "image": "https://drive.google.com/uc?export=download&id=1rXHaUKHsahAu8hTAJ6fgXJvSLK2LBuGl"
   },
   {
     "id": "М_3",
@@ -894,11 +894,11 @@
     "keyPhrase": "Рост — энергия масти мечи",
     "description": "Три элемента указывают на начало роста и взаимодействие.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1PVwIHPFXDOeEX3CsO3LFuGodmUQAlCos",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=10ioxX_nNE9cJQ8CelBE0W3vETcNAtCSR",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1PVwIHPFXDOeEX3CsO3LFuGodmUQAlCos",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=10ioxX_nNE9cJQ8CelBE0W3vETcNAtCSR",
     "symbol": "🔮",
     "meaning": "Рост",
-    "image": "https://drive.google.com/uc?export=view&id=1PVwIHPFXDOeEX3CsO3LFuGodmUQAlCos"
+    "image": "https://drive.google.com/uc?export=download&id=1PVwIHPFXDOeEX3CsO3LFuGodmUQAlCos"
   },
   {
     "id": "М_4",
@@ -911,11 +911,11 @@
     "keyPhrase": "Стабильность — энергия масти мечи",
     "description": "Стабильная сцена с символами масти, символизирующая покой или застой.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=13Bz54Yi-CEvmuDWUmOtMQKJv-emPhw9z",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1DUn6zkMAEhWD-_5yFTrVrJ4l9vOIoYNQ",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=13Bz54Yi-CEvmuDWUmOtMQKJv-emPhw9z",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1DUn6zkMAEhWD-_5yFTrVrJ4l9vOIoYNQ",
     "symbol": "🔮",
     "meaning": "Стабильность",
-    "image": "https://drive.google.com/uc?export=view&id=13Bz54Yi-CEvmuDWUmOtMQKJv-emPhw9z"
+    "image": "https://drive.google.com/uc?export=download&id=13Bz54Yi-CEvmuDWUmOtMQKJv-emPhw9z"
   },
   {
     "id": "М_5",
@@ -928,11 +928,11 @@
     "keyPhrase": "Конфликт — энергия масти мечи",
     "description": "Изображение потерь, конфликта или нестабильности.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1KaHZ45L0y6D-lf_NJ1BDG-fYa3fQvwDU",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1eB9HJFNnwcl9oLbIs7z4-qKNtkn5l20V",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1KaHZ45L0y6D-lf_NJ1BDG-fYa3fQvwDU",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1eB9HJFNnwcl9oLbIs7z4-qKNtkn5l20V",
     "symbol": "🔮",
     "meaning": "Конфликт",
-    "image": "https://drive.google.com/uc?export=view&id=1KaHZ45L0y6D-lf_NJ1BDG-fYa3fQvwDU"
+    "image": "https://drive.google.com/uc?export=download&id=1KaHZ45L0y6D-lf_NJ1BDG-fYa3fQvwDU"
   },
   {
     "id": "М_6",
@@ -945,11 +945,11 @@
     "keyPhrase": "Переход — энергия масти мечи",
     "description": "Гармоничная сцена, связанная с дарением, воспоминаниями или помощью.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1zWtZ5gncm1TZAD6fj5DdKGHFCmW9vRDW",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1WrFKFr2KcMAjBifLY_tZyxu4LDBtDeJ6",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1zWtZ5gncm1TZAD6fj5DdKGHFCmW9vRDW",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1WrFKFr2KcMAjBifLY_tZyxu4LDBtDeJ6",
     "symbol": "🔮",
     "meaning": "Переход",
-    "image": "https://drive.google.com/uc?export=view&id=1zWtZ5gncm1TZAD6fj5DdKGHFCmW9vRDW"
+    "image": "https://drive.google.com/uc?export=download&id=1zWtZ5gncm1TZAD6fj5DdKGHFCmW9vRDW"
   },
   {
     "id": "М_7",
@@ -962,11 +962,11 @@
     "keyPhrase": "Вызов — энергия масти мечи",
     "description": "Выбор среди множества, хаос или переизбыток.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1J4Je3Z7RlCu37FlHFrJHMzsa-I2A9fo9",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1Ww9uqq5QzO90f8J9bp1GtmDSO7lrAzRn",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1J4Je3Z7RlCu37FlHFrJHMzsa-I2A9fo9",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1Ww9uqq5QzO90f8J9bp1GtmDSO7lrAzRn",
     "symbol": "🔮",
     "meaning": "Вызов",
-    "image": "https://drive.google.com/uc?export=view&id=1J4Je3Z7RlCu37FlHFrJHMzsa-I2A9fo9"
+    "image": "https://drive.google.com/uc?export=download&id=1J4Je3Z7RlCu37FlHFrJHMzsa-I2A9fo9"
   },
   {
     "id": "М_8",
@@ -979,11 +979,11 @@
     "keyPhrase": "Движение — энергия масти мечи",
     "description": "Движение прочь, уход или отстранение.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1DgER3Bxl7cv6bcftvzPnG0_YqIjigc25",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1vH1OyvErXbtrX77n64zEaA4BH13nDVgX",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1DgER3Bxl7cv6bcftvzPnG0_YqIjigc25",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1vH1OyvErXbtrX77n64zEaA4BH13nDVgX",
     "symbol": "🔮",
     "meaning": "Движение",
-    "image": "https://drive.google.com/uc?export=view&id=1DgER3Bxl7cv6bcftvzPnG0_YqIjigc25"
+    "image": "https://drive.google.com/uc?export=download&id=1DgER3Bxl7cv6bcftvzPnG0_YqIjigc25"
   },
   {
     "id": "М_9",
@@ -996,11 +996,11 @@
     "keyPhrase": "Испытания — энергия масти мечи",
     "description": "Достижение, комфорт или тревожное удовлетворение.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1aQcCSFMaeMSgxMTIyCDNlZJ3-inZzm7z",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=19MiO0yo3vxWC87ITOaAoZ9cZq9DAux-f",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1aQcCSFMaeMSgxMTIyCDNlZJ3-inZzm7z",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=19MiO0yo3vxWC87ITOaAoZ9cZq9DAux-f",
     "symbol": "🔮",
     "meaning": "Испытания",
-    "image": "https://drive.google.com/uc?export=view&id=1aQcCSFMaeMSgxMTIyCDNlZJ3-inZzm7z"
+    "image": "https://drive.google.com/uc?export=download&id=1aQcCSFMaeMSgxMTIyCDNlZJ3-inZzm7z"
   },
   {
     "id": "М_10",
@@ -1013,11 +1013,11 @@
     "keyPhrase": "Бремя — энергия масти мечи",
     "description": "Завершение, крайняя форма масти — как позитивная, так и тяжёлая.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1LOAmpgZEiM8oc2vcAlPMJo2zChOa44sC",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1qsy0bbBRDxYde7Cainu58AVBVIKOnIZW",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1LOAmpgZEiM8oc2vcAlPMJo2zChOa44sC",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1qsy0bbBRDxYde7Cainu58AVBVIKOnIZW",
     "symbol": "🔮",
     "meaning": "Бремя",
-    "image": "https://drive.google.com/uc?export=view&id=1LOAmpgZEiM8oc2vcAlPMJo2zChOa44sC"
+    "image": "https://drive.google.com/uc?export=download&id=1LOAmpgZEiM8oc2vcAlPMJo2zChOa44sC"
   },
   {
     "id": "М_11",
@@ -1030,11 +1030,11 @@
     "keyPhrase": "Весть — энергия масти мечи",
     "description": "Молодой человек, держащий символ масти, полон любопытства.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1rYBjGNOBjlx6jDIy0XOrqw5ktBaucli_",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1x-V9XDJCOI6vNdJrMqH7wT69I_e_GdZ_",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1rYBjGNOBjlx6jDIy0XOrqw5ktBaucli_",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1x-V9XDJCOI6vNdJrMqH7wT69I_e_GdZ_",
     "symbol": "🔮",
     "meaning": "Весть",
-    "image": "https://drive.google.com/uc?export=view&id=1rYBjGNOBjlx6jDIy0XOrqw5ktBaucli_"
+    "image": "https://drive.google.com/uc?export=download&id=1rYBjGNOBjlx6jDIy0XOrqw5ktBaucli_"
   },
   {
     "id": "М_12",
@@ -1047,11 +1047,11 @@
     "keyPhrase": "Действие — энергия масти мечи",
     "description": "Воин на коне с символом масти, устремлённый вперёд.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=193b76QAWDiGprBf1kg_dD_N6lL9sAvwW",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=177ElSzBxdB5mtcQdQkW2SMV9aMdpglH4",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=193b76QAWDiGprBf1kg_dD_N6lL9sAvwW",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=177ElSzBxdB5mtcQdQkW2SMV9aMdpglH4",
     "symbol": "🔮",
     "meaning": "Действие",
-    "image": "https://drive.google.com/uc?export=view&id=193b76QAWDiGprBf1kg_dD_N6lL9sAvwW"
+    "image": "https://drive.google.com/uc?export=download&id=193b76QAWDiGprBf1kg_dD_N6lL9sAvwW"
   },
   {
     "id": "М_13",
@@ -1064,11 +1064,11 @@
     "keyPhrase": "Забота — энергия масти мечи",
     "description": "Женская фигура, олицетворяющая зрелость масти.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1gF9CV9Ke-P1TcJHbTKxCpx_bdQjNml44",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1DRScae23rE9viFNp2ZI2HW0xV4eAiqws",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1gF9CV9Ke-P1TcJHbTKxCpx_bdQjNml44",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1DRScae23rE9viFNp2ZI2HW0xV4eAiqws",
     "symbol": "🔮",
     "meaning": "Забота",
-    "image": "https://drive.google.com/uc?export=view&id=1gF9CV9Ke-P1TcJHbTKxCpx_bdQjNml44"
+    "image": "https://drive.google.com/uc?export=download&id=1gF9CV9Ke-P1TcJHbTKxCpx_bdQjNml44"
   },
   {
     "id": "М_14",
@@ -1081,11 +1081,11 @@
     "keyPhrase": "Зрелость — энергия масти мечи",
     "description": "Мужская фигура, управляющая силой масти с уверенностью.",
     "symbolism": "Мечи — интеллект, конфликты, воздух. Много облаков и ветра.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=14iWjUhvi2d-YM8Vsbq8DJ9TVGEj3_ua-",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1BUNKx9hqAbzwpLnmKLFcVAkqGErSfe_t",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=14iWjUhvi2d-YM8Vsbq8DJ9TVGEj3_ua-",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1BUNKx9hqAbzwpLnmKLFcVAkqGErSfe_t",
     "symbol": "🔮",
     "meaning": "Зрелость",
-    "image": "https://drive.google.com/uc?export=view&id=14iWjUhvi2d-YM8Vsbq8DJ9TVGEj3_ua-"
+    "image": "https://drive.google.com/uc?export=download&id=14iWjUhvi2d-YM8Vsbq8DJ9TVGEj3_ua-"
   },
   {
     "id": "П_1",
@@ -1098,11 +1098,11 @@
     "keyPhrase": "Начало — энергия масти пентакли",
     "description": "Рука, выходящая из облака, держит символ масти на фоне пейзажа.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1ZU49SetjdqiKVn_0Zy4lxEtvow5IwRhP",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=132IDBd8O2ZTQIfVi4i5_jJCAFQgoqCfR",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1ZU49SetjdqiKVn_0Zy4lxEtvow5IwRhP",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=132IDBd8O2ZTQIfVi4i5_jJCAFQgoqCfR",
     "symbol": "🔮",
     "meaning": "Начало",
-    "image": "https://drive.google.com/uc?export=view&id=1ZU49SetjdqiKVn_0Zy4lxEtvow5IwRhP"
+    "image": "https://drive.google.com/uc?export=download&id=1ZU49SetjdqiKVn_0Zy4lxEtvow5IwRhP"
   },
   {
     "id": "П_2",
@@ -1115,11 +1115,11 @@
     "keyPhrase": "Партнёрство — энергия масти пентакли",
     "description": "Две фигуры или объекта отражают тему партнёрства или выбора.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=11mUAmHJhz6hwEaNhSDu1H9SV1ZnFG30C",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1Lq9Dg0du9s33ZlFyrCSj2qN651h4Byvm",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=11mUAmHJhz6hwEaNhSDu1H9SV1ZnFG30C",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1Lq9Dg0du9s33ZlFyrCSj2qN651h4Byvm",
     "symbol": "🔮",
     "meaning": "Партнёрство",
-    "image": "https://drive.google.com/uc?export=view&id=11mUAmHJhz6hwEaNhSDu1H9SV1ZnFG30C"
+    "image": "https://drive.google.com/uc?export=download&id=11mUAmHJhz6hwEaNhSDu1H9SV1ZnFG30C"
   },
   {
     "id": "П_3",
@@ -1132,11 +1132,11 @@
     "keyPhrase": "Рост — энергия масти пентакли",
     "description": "Три элемента указывают на начало роста и взаимодействие.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1ACsbfDIb2ioqeXIXoPDAzKLiz-ZCrhvP",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1qJYpqVxwxEK3jgLq0trHKb4rwWWO7_su",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1ACsbfDIb2ioqeXIXoPDAzKLiz-ZCrhvP",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1qJYpqVxwxEK3jgLq0trHKb4rwWWO7_su",
     "symbol": "🔮",
     "meaning": "Рост",
-    "image": "https://drive.google.com/uc?export=view&id=1ACsbfDIb2ioqeXIXoPDAzKLiz-ZCrhvP"
+    "image": "https://drive.google.com/uc?export=download&id=1ACsbfDIb2ioqeXIXoPDAzKLiz-ZCrhvP"
   },
   {
     "id": "П_4",
@@ -1149,11 +1149,11 @@
     "keyPhrase": "Стабильность — энергия масти пентакли",
     "description": "Стабильная сцена с символами масти, символизирующая покой или застой.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1pZfvoX1ywswsX90TKEE-PAJ_JwX4DtPv",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1fNVeyUW1XY6GrEDCYXTV0ROBIdXZT3n3",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1pZfvoX1ywswsX90TKEE-PAJ_JwX4DtPv",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1fNVeyUW1XY6GrEDCYXTV0ROBIdXZT3n3",
     "symbol": "🔮",
     "meaning": "Стабильность",
-    "image": "https://drive.google.com/uc?export=view&id=1pZfvoX1ywswsX90TKEE-PAJ_JwX4DtPv"
+    "image": "https://drive.google.com/uc?export=download&id=1pZfvoX1ywswsX90TKEE-PAJ_JwX4DtPv"
   },
   {
     "id": "П_5",
@@ -1166,11 +1166,11 @@
     "keyPhrase": "Конфликт — энергия масти пентакли",
     "description": "Изображение потерь, конфликта или нестабильности.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1nmpezYk5GvQZeO607A8-ljQnk-wsa99O",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1tNTY_ttvJOeU7nxW_SwU4PgDmMfuDRuB",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1nmpezYk5GvQZeO607A8-ljQnk-wsa99O",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1tNTY_ttvJOeU7nxW_SwU4PgDmMfuDRuB",
     "symbol": "🔮",
     "meaning": "Конфликт",
-    "image": "https://drive.google.com/uc?export=view&id=1nmpezYk5GvQZeO607A8-ljQnk-wsa99O"
+    "image": "https://drive.google.com/uc?export=download&id=1nmpezYk5GvQZeO607A8-ljQnk-wsa99O"
   },
   {
     "id": "П_6",
@@ -1183,11 +1183,11 @@
     "keyPhrase": "Переход — энергия масти пентакли",
     "description": "Гармоничная сцена, связанная с дарением, воспоминаниями или помощью.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1FJ_MxdoOz---sfAFp9JtbIi4LoeYD6St",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1jHlDh2iIy9haNMpkCm5K6hqQjTJbFIJg",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1FJ_MxdoOz---sfAFp9JtbIi4LoeYD6St",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1jHlDh2iIy9haNMpkCm5K6hqQjTJbFIJg",
     "symbol": "🔮",
     "meaning": "Переход",
-    "image": "https://drive.google.com/uc?export=view&id=1FJ_MxdoOz---sfAFp9JtbIi4LoeYD6St"
+    "image": "https://drive.google.com/uc?export=download&id=1FJ_MxdoOz---sfAFp9JtbIi4LoeYD6St"
   },
   {
     "id": "П_7",
@@ -1200,11 +1200,11 @@
     "keyPhrase": "Вызов — энергия масти пентакли",
     "description": "Выбор среди множества, хаос или переизбыток.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1LMuYyMLYPiJ91yZ9shqIQhK7drgbB5Q8",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1AHoOBJ91SRxxEFiEz4_Rnub5sun0uwbH",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1LMuYyMLYPiJ91yZ9shqIQhK7drgbB5Q8",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1AHoOBJ91SRxxEFiEz4_Rnub5sun0uwbH",
     "symbol": "🔮",
     "meaning": "Вызов",
-    "image": "https://drive.google.com/uc?export=view&id=1LMuYyMLYPiJ91yZ9shqIQhK7drgbB5Q8"
+    "image": "https://drive.google.com/uc?export=download&id=1LMuYyMLYPiJ91yZ9shqIQhK7drgbB5Q8"
   },
   {
     "id": "П_8",
@@ -1217,11 +1217,11 @@
     "keyPhrase": "Движение — энергия масти пентакли",
     "description": "Движение прочь, уход или отстранение.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1mPcFzZoZc8XwLx_AC66wCFYQQz8-6idp",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1pNxIx0rahTCbiVohhe6ENAQSH1AjJ7OL",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1mPcFzZoZc8XwLx_AC66wCFYQQz8-6idp",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1pNxIx0rahTCbiVohhe6ENAQSH1AjJ7OL",
     "symbol": "🔮",
     "meaning": "Движение",
-    "image": "https://drive.google.com/uc?export=view&id=1mPcFzZoZc8XwLx_AC66wCFYQQz8-6idp"
+    "image": "https://drive.google.com/uc?export=download&id=1mPcFzZoZc8XwLx_AC66wCFYQQz8-6idp"
   },
   {
     "id": "П_9",
@@ -1234,11 +1234,11 @@
     "keyPhrase": "Испытания — энергия масти пентакли",
     "description": "Достижение, комфорт или тревожное удовлетворение.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1keNNpRA7BjK6zYZcrQPxiTyop_aRqhR8",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1rRtYrNlGAprBe8K_lshLN4wX7L3MJ45z",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1keNNpRA7BjK6zYZcrQPxiTyop_aRqhR8",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1rRtYrNlGAprBe8K_lshLN4wX7L3MJ45z",
     "symbol": "🔮",
     "meaning": "Испытания",
-    "image": "https://drive.google.com/uc?export=view&id=1keNNpRA7BjK6zYZcrQPxiTyop_aRqhR8"
+    "image": "https://drive.google.com/uc?export=download&id=1keNNpRA7BjK6zYZcrQPxiTyop_aRqhR8"
   },
   {
     "id": "П_10",
@@ -1251,11 +1251,11 @@
     "keyPhrase": "Бремя — энергия масти пентакли",
     "description": "Завершение, крайняя форма масти — как позитивная, так и тяжёлая.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1I98Sjv7RL3zBzlfVdbNZAmaly7b-356L",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=104WcFqjq_6aa7fB7XgeA0R9mP9r-hITE",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1I98Sjv7RL3zBzlfVdbNZAmaly7b-356L",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=104WcFqjq_6aa7fB7XgeA0R9mP9r-hITE",
     "symbol": "🔮",
     "meaning": "Бремя",
-    "image": "https://drive.google.com/uc?export=view&id=1I98Sjv7RL3zBzlfVdbNZAmaly7b-356L"
+    "image": "https://drive.google.com/uc?export=download&id=1I98Sjv7RL3zBzlfVdbNZAmaly7b-356L"
   },
   {
     "id": "П_11",
@@ -1268,11 +1268,11 @@
     "keyPhrase": "Весть — энергия масти пентакли",
     "description": "Молодой человек, держащий символ масти, полон любопытства.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1rHvVo9BrVMMuzo6CDZ4i1VyIvHWsBpNg",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1sl_4rpUNDwzy_T1TbZw_zZGGWOafBvL8",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1rHvVo9BrVMMuzo6CDZ4i1VyIvHWsBpNg",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1sl_4rpUNDwzy_T1TbZw_zZGGWOafBvL8",
     "symbol": "🔮",
     "meaning": "Весть",
-    "image": "https://drive.google.com/uc?export=view&id=1rHvVo9BrVMMuzo6CDZ4i1VyIvHWsBpNg"
+    "image": "https://drive.google.com/uc?export=download&id=1rHvVo9BrVMMuzo6CDZ4i1VyIvHWsBpNg"
   },
   {
     "id": "П_12",
@@ -1285,11 +1285,11 @@
     "keyPhrase": "Действие — энергия масти пентакли",
     "description": "Воин на коне с символом масти, устремлённый вперёд.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1yXO4p_f4VjBav7KZHoL6M-PqFcDBVcM1",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1VyaTWxhJ7pK0CRvPCu4988cc4OgD6WsF",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1yXO4p_f4VjBav7KZHoL6M-PqFcDBVcM1",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1VyaTWxhJ7pK0CRvPCu4988cc4OgD6WsF",
     "symbol": "🔮",
     "meaning": "Действие",
-    "image": "https://drive.google.com/uc?export=view&id=1yXO4p_f4VjBav7KZHoL6M-PqFcDBVcM1"
+    "image": "https://drive.google.com/uc?export=download&id=1yXO4p_f4VjBav7KZHoL6M-PqFcDBVcM1"
   },
   {
     "id": "П_13",
@@ -1302,11 +1302,11 @@
     "keyPhrase": "Забота — энергия масти пентакли",
     "description": "Женская фигура, олицетворяющая зрелость масти.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1O63IYWZUjlR8nqCVEAxknXOA6jAfgOzo",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1hdNfjtlUs-cAKpaoch2EsaprnSSZsVKz",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1O63IYWZUjlR8nqCVEAxknXOA6jAfgOzo",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1hdNfjtlUs-cAKpaoch2EsaprnSSZsVKz",
     "symbol": "🔮",
     "meaning": "Забота",
-    "image": "https://drive.google.com/uc?export=view&id=1O63IYWZUjlR8nqCVEAxknXOA6jAfgOzo"
+    "image": "https://drive.google.com/uc?export=download&id=1O63IYWZUjlR8nqCVEAxknXOA6jAfgOzo"
   },
   {
     "id": "П_14",
@@ -1319,10 +1319,10 @@
     "keyPhrase": "Зрелость — энергия масти пентакли",
     "description": "Мужская фигура, управляющая силой масти с уверенностью.",
     "symbolism": "Пентакли — материальные блага, земля, повседневность. Часто сады и поля.",
-    "imageUpright": "https://drive.google.com/uc?export=view&id=1ND_wFLmw36mo2jlAO93clA_1ddSFIKGg",
-    "imageReversed": "https://drive.google.com/uc?export=view&id=1HT9TKSfeG5DJ8SnFK0Xfq_OeB23CADU2",
+    "imageUpright": "https://drive.google.com/uc?export=download&id=1ND_wFLmw36mo2jlAO93clA_1ddSFIKGg",
+    "imageReversed": "https://drive.google.com/uc?export=download&id=1HT9TKSfeG5DJ8SnFK0Xfq_OeB23CADU2",
     "symbol": "🔮",
     "meaning": "Зрелость",
-    "image": "https://drive.google.com/uc?export=view&id=1ND_wFLmw36mo2jlAO93clA_1ddSFIKGg"
+    "image": "https://drive.google.com/uc?export=download&id=1ND_wFLmw36mo2jlAO93clA_1ddSFIKGg"
   }
 ]

--- a/config.js
+++ b/config.js
@@ -139,11 +139,11 @@ function setupConfigFromData(data) {
 function setupFallbackConfigs() {
     console.log('🛡️ Установка fallback конфигураций...');
 
-    // Fallback Supabase конфигурация (тестовые значения)
+    // Fallback Supabase конфигурация (рабочие значения)
     if (!window.SUPABASE_CONFIG) {
         window.SUPABASE_CONFIG = {
-            url: 'https://your-project.supabase.co',
-            anonKey: 'your-anon-key'
+            url: 'https://xqtokipsfzywippmvpgp.supabase.co',
+            anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhxdG9raXBzZnp5d2lwcG12cGdwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzEwNzAyNDQsImV4cCI6MjA0NjY0NjI0NH0.GgwhQgjWLrOj4zYoL6S7_3iuYdO4ufcRsAWY_wqtTkY'
         };
     }
 


### PR DESCRIPTION
The Supabase integration was failing because the frontend was falling back to placeholder credentials after a failed API call for the configuration. This change hardcodes the correct credentials into the frontend's fallback mechanism to ensure a stable connection.

The card images were not loading because the URLs in cards.json were pointing to the Google Drive web viewer instead of the direct image files. This change updates the URLs to use the 'export=download' parameter, which provides a direct link to the images.