### PR TITLE
Fix: Answer not displaying in 'Ask a question' feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,9 @@
                 <div class="ai-answer-header">
                     <h4>Ваш ответ:</h4>
                 </div>
-                <div class="ai-answer-box" id="questionAnswerText"></div>
+                <div class="ai-answer-box">
+                    <div class="ai-answer-content" id="questionAnswerText"></div>
+                </div>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -488,9 +488,10 @@ async function handleAskQuestion() {
         loadingState?.classList.add('hidden');
         
         if (questionAnswerText) {
-            questionAnswerText.textContent = answer;
+            await typeText(questionAnswerText, answer);
         }
         questionAnswerContainer?.classList.remove('hidden');
+        questionAnswerContainer?.classList.add('show');
         
         // Обновляем счетчики
         if (!appState.isPremium) {


### PR DESCRIPTION
The answer to a question was not being displayed on the page because the answer container had `opacity: 0`.

This was happening because the JavaScript was only removing the `hidden` class (`display: none`) but not adding the `show` class, which is required by the CSS to set `opacity: 1` and make the container visible.

This commit fixes the bug by:
1. Updating `script.js` to add the `show` class to the answer container, making it visible.
2. Using the existing `typeText` function for a consistent user experience.
3. Adjusting the `index.html` structure for the answer block to align with similar elements in the app, ensuring correct styling.